### PR TITLE
Support apps without `jbuilder` in Gemfile

### DIFF
--- a/lib/inertia_builder.rb
+++ b/lib/inertia_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'jbuilder/jbuilder_template'
+require 'jbuilder'
 require 'inertia_builder/handler'
 require 'inertia_builder/controller'
 require 'inertia_builder/renderer'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@
 require 'rails'
 require 'action_controller/railtie'
 
-require 'jbuilder'
 require 'inertia_rails'
 require 'inertia_builder'
 require 'active_support/testing/autorun'


### PR DESCRIPTION
This fixes https://github.com/rodrigotavio91/inertia-builder/issues/2.

TLDR: either the gem or the app needs to `require 'jbuilder'`.

---

Adding `inertia_builder` to the Gemfile without `jbuilder` leads to:

```
NameError: undefined method 'attributes!' for class 'InertiaBuilder::PropBuilder' (NameError)
```

**How to repo**

The test suite didn't catch this because of the explicit ` require 'jbuilder'` in `test_helper.rb`

https://github.com/rodrigotavio91/inertia-builder/blob/f17d264a7d50037be33a7b0bd6c64843c7180473/test/test_helper.rb#L6

Running the tests without it would fail with:

```
BUNDLE_GEMFILE=gemfiles/rails_8_0.gemfile bundle exec rake test
inertia-builder/lib/inertia_builder.rb:15:in '<class:PropBuilder>': undefined method 'attributes!' for class 'InertiaBuilder::PropBuilder' (NameError)
Did you mean?  attr_writer
```

Or, try removing `jbuilder` from https://github.com/rodrigotavio91/trellix-inertia-builder/blob/9c2aad397fe0b42ec6ead957d93009fb9c198e38/Gemfile#L18.

**Why is this happening?**


- `attributes!` along with most core jbuilder methods are defined in [`lib/jbuilder.rb`](https://github.com/rails/jbuilder/blob/4869a93ee0728bfa98eab0589f769f203828c754/lib/jbuilder.rb#L11)
- We only `require 'jbuilder/jbuilder_template'`, which will define those methods because [`lib/jbuilder/jbuilder_template.rb`](https://github.com/rails/jbuilder/blob/4869a93ee0728bfa98eab0589f769f203828c754/lib/jbuilder/jbuilder_template.rb#L3-L6) doesn't load `lib/jbuilder.rb` either
- Lastly, Bundler only auto loads gem explicitly listed in the Gemfile.

Thus: no `gem 'jbuidler` ->  no `require 'jbuilder'` -> `attributes!` and other core methods never defined -> the `NameError` we saw earlier.

**Is this the right approach?**

Frankly, I don't know enough about the best practices when managing dependencies within a gem. 

The alternative is to document apps are required to explicitly install `gem 'jbuilder'`, too.

I guess this also comes down to `inertia-builder`'s approach: is `jbuilder` an implementation detail or is it a requirement that this builds on top of?

---

Either way, thanks for creating this and feel free to close if this doesn't align with what you have in mind!