### PR TITLE
Support InertiaRails.scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ prop.defer! group: :comments do
 end
 ```
 
+## Infinite scrolling
+
+InertiaBuilder supports [`InertiaRails.scroll`](https://inertia-rails.dev/guide/infinite-scroll) infinite scrolling.
+
+```ruby
+# Custom metadata
+prop.id @post.id
+prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
+  prop.comments @post.comments, partial: 'comments/comment', as: :comment
+end
+
+# Pagy instance
+prop.id @post.id
+prop.scroll!(@pagy) do
+  prop.comments @records, partial: 'comments/comment', as: :comment
+end
+```
+
+See the `inertia-rails` documentation for the [supported pagination libraries](https://inertia-rails.dev/guide/infinite-scroll#inertiarails-scroll-method), and how to create [custom pagination adapters](https://inertia-rails.dev/guide/infinite-scroll#custom-pagination-adapters).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ InertiaBuilder supports [`InertiaRails.scroll`](https://inertia-rails.dev/guide/
 ```ruby
 # Custom metadata
 prop.id @post.id
-prop.scroll!({ page_name: 'page', current_page: 1, previous_page: nil, next_page: 2 }) do
+prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
   prop.comments @post.comments, partial: 'comments/comment', as: :comment
 end
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ InertiaBuilder supports [`InertiaRails.scroll`](https://inertia-rails.dev/guide/
 ```ruby
 # Custom metadata
 prop.id @post.id
-prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
+prop.scroll!({ page_name: 'page', current_page: 1, previous_page: nil, next_page: 2 }) do
   prop.comments @post.comments, partial: 'comments/comment', as: :comment
 end
 

--- a/inertia_builder.gemspec
+++ b/inertia_builder.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_dependency 'inertia_rails', '~> 3.5'
+  s.add_dependency 'inertia_rails', '~> 3.12'
   s.add_dependency 'jbuilder', '~> 2.0'
 
   s.add_development_dependency 'appraisal'

--- a/lib/inertia_builder.rb
+++ b/lib/inertia_builder.rb
@@ -26,12 +26,16 @@ module InertiaBuilder
       _call_inertia_block(:defer, **opts, &block)
     end
 
+    def scroll!(metadata = nil, **opts, &block)
+      _call_inertia_block(:scroll, metadata, **opts, &block)
+    end
+
     def method_missing(name, *args, &block)
       prop = self
 
       if @inertia_block
-        method, opts = @inertia_block
-        _set_value(name, ::InertiaRails.send(method, **opts) { prop.set!(name, *args, &block) })
+        method, positional_args, opts = @inertia_block
+        _set_value(name, ::InertiaRails.send(method, *positional_args, **opts) { prop.set!(name, *args, &block) })
       elsif !@in_scope
         # Lazy evaluate outermost properties.
         _set_value(name, -> { prop.set!(name, *args, &block); })
@@ -42,10 +46,10 @@ module InertiaBuilder
 
     private
 
-    def _call_inertia_block(method, **opts)
+    def _call_inertia_block(method, *args, **opts)
       ::Kernel.raise "Nesting #{method}! in a #{@inertia_block[0]}! block is not allowed" if @inertia_block
 
-      @inertia_block = [method, opts]
+      @inertia_block = [method, args, opts]
       yield
       @inertia_block = nil
     end
@@ -78,7 +82,8 @@ module InertiaBuilder
       if current_value.is_a?(::Proc) ||
          current_value.is_a?(::InertiaRails::OptionalProp) ||
          current_value.is_a?(::InertiaRails::AlwaysProp) ||
-         current_value.is_a?(::InertiaRails::DeferProp)
+         current_value.is_a?(::InertiaRails::DeferProp) ||
+         current_value.is_a?(::InertiaRails::ScrollProp)
         updates
       else
         super

--- a/test/inertia_builder_test.rb
+++ b/test/inertia_builder_test.rb
@@ -13,7 +13,7 @@ class Item < Struct.new(:id, :title)
   include ActiveModel::Conversion
 end
 
-Paginator = Struct.new(:current, :previous, :next, :param_name)
+Paginator = Struct.new(:current, :previous, :next, :param_name, keyword_init: true)
 
 class PaginatorAdapter
   def match?(metadata)

--- a/test/inertia_builder_test.rb
+++ b/test/inertia_builder_test.rb
@@ -285,7 +285,7 @@ class InertiaBuilderTest < Minitest::Test
 
     template = <<~INERTIA
       prop.id 1
-      prop.scroll!({ page_name: 'page', current_page: 1, previous_page: nil, next_page: 2 }) do
+      prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
         prop.users @users, partial: 'users/user', as: :user
       end
     INERTIA
@@ -307,7 +307,7 @@ class InertiaBuilderTest < Minitest::Test
 
     template = <<~INERTIA
       prop.id 1
-      prop.scroll!({ page_name: 'page', current_page: 2, previous_page: 1, next_page: 3 }) do
+      prop.scroll!(page_name: 'page', current_page: 2, previous_page: 1, next_page: 3) do
         prop.users @users, partial: 'users/user', as: :user
       end
     INERTIA

--- a/test/inertia_builder_test.rb
+++ b/test/inertia_builder_test.rb
@@ -285,7 +285,7 @@ class InertiaBuilderTest < Minitest::Test
 
     template = <<~INERTIA
       prop.id 1
-      prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
+      prop.scroll!({ page_name: 'page', current_page: 1, previous_page: nil, next_page: 2 }) do
         prop.users @users, partial: 'users/user', as: :user
       end
     INERTIA
@@ -307,7 +307,7 @@ class InertiaBuilderTest < Minitest::Test
 
     template = <<~INERTIA
       prop.id 1
-      prop.scroll!(page_name: 'page', current_page: 2, previous_page: 1, next_page: 3) do
+      prop.scroll!({ page_name: 'page', current_page: 2, previous_page: 1, next_page: 3 }) do
         prop.users @users, partial: 'users/user', as: :user
       end
     INERTIA

--- a/test/inertia_builder_test.rb
+++ b/test/inertia_builder_test.rb
@@ -13,6 +13,23 @@ class Item < Struct.new(:id, :title)
   include ActiveModel::Conversion
 end
 
+Paginator = Struct.new(:current, :previous, :next, :param_name)
+
+class PaginatorAdapter
+  def match?(metadata)
+    metadata.is_a?(Paginator)
+  end
+
+  def call(metadata, **_options)
+    {
+      page_name: metadata.param_name,
+      previous_page: metadata.previous,
+      next_page: metadata.next,
+      current_page: metadata.current
+    }
+  end
+end
+
 class InertiaBuilderTest < Minitest::Test
   USER_PARTIAL = <<~INERTIA
     prop.id user.id
@@ -260,6 +277,79 @@ class InertiaBuilderTest < Minitest::Test
                  render_view(template, assigns: { user: user }, json: true, headers: partial_headers)
   end
 
+  def test_scroll_block
+    users = [
+      User.new(id: 1, first_name: 'John', last_name: 'Smith', email: 'john@email.com'),
+      User.new(id: 2, first_name: 'Jane', last_name: 'Smith', email: 'jane@email.com')
+    ]
+
+    template = <<~INERTIA
+      prop.id 1
+      prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
+        prop.users @users, partial: 'users/user', as: :user
+      end
+    INERTIA
+
+    expected = inertia_json_with_props(
+      { id: 1, users: users },
+      scrollProps: { users: { pageName: 'page', previousPage: nil, nextPage: 2, currentPage: 1, reset: false } },
+      mergeProps: ['users']
+    )
+
+    assert_equal expected, render_view(template, assigns: { users: users }, json: true)
+  end
+
+  def test_scroll_block_fetching
+    users = [
+      User.new(id: 3, first_name: 'Alice', last_name: 'Jones', email: 'alice@email.com'),
+      User.new(id: 4, first_name: 'Bob', last_name: 'Brown', email: 'bob@email.com')
+    ]
+
+    template = <<~INERTIA
+      prop.id 1
+      prop.scroll!(page_name: 'page', current_page: 2, previous_page: 1, next_page: 3) do
+        prop.users @users, partial: 'users/user', as: :user
+      end
+    INERTIA
+
+    partial_headers = {
+      'X-Inertia-Partial-Data' => 'users',
+      'X-Inertia-Partial-Component' => '/'
+    }
+    expected = inertia_json_with_props(
+      { users: users },
+      scrollProps: { users: { pageName: 'page', previousPage: 1, nextPage: 3, currentPage: 2, reset: false } },
+      mergeProps: ['users']
+    )
+
+    assert_equal expected, render_view(template, assigns: { users: users }, json: true, headers: partial_headers)
+  end
+
+  def test_scroll_block_with_metadata_extractor
+    users = [
+      User.new(id: 1, first_name: 'John', last_name: 'Smith', email: 'john@email.com')
+    ]
+
+    paginator = Paginator.new(current: 1, previous: nil, next: 2, param_name: 'p')
+
+    template = <<~INERTIA
+      prop.id 1
+      prop.scroll!(@paginator) do
+        prop.users @users, partial: 'users/user', as: :user
+      end
+    INERTIA
+
+    with_scroll_metadata_adapater(PaginatorAdapter) do
+      expected = inertia_json_with_props(
+        { id: 1, users: users },
+        scrollProps: { users: { pageName: 'p', previousPage: nil, nextPage: 2, currentPage: 1, reset: false } },
+        mergeProps: ['users']
+      )
+
+      assert_equal expected, render_view(template, assigns: { users: users, paginator: paginator }, json: true)
+    end
+  end
+
   private
 
   def render_view(source, **opts)
@@ -293,5 +383,13 @@ class InertiaBuilderTest < Minitest::Test
       encryptHistory: false,
       clearHistory: false
     }.merge(extra_fields).to_json
+  end
+
+  def with_scroll_metadata_adapater(adapter_class)
+    original_adapters = InertiaRails::ScrollMetadata.adapters.dup
+    InertiaRails::ScrollMetadata.register_adapter(adapter_class)
+    yield
+  ensure
+    InertiaRails::ScrollMetadata.adapters = original_adapters
   end
 end


### PR DESCRIPTION
Recently came across [`InertiaRails.scroll`](https://inertia-rails.dev/guide/infinite-scroll) and this adds support for it.

```ruby
# Custom metadata
prop.id @post.id
prop.scroll!(page_name: 'page', current_page: 1, previous_page: nil, next_page: 2) do
  prop.comments @post.comments, partial: 'comments/comment', as: :comment
end

# Pagy instance
prop.id @post.id
prop.scroll!(@pagy) do
  prop.comments @records, partial: 'comments/comment', as: :comment
end
```

The core change is to allow both positional arguments and keyword arguments for `_call_inertia_block`.

Thanks and open to suggestions!