### PR TITLE
Fix deprecation warning by removing view_data reference

### DIFF
--- a/lib/inertia_builder/renderer.rb
+++ b/lib/inertia_builder/renderer.rb
@@ -23,7 +23,7 @@ module InertiaBuilder
         @view_context.controller.render_to_string(
           template: 'inertia',
           layout: false,
-          locals: @inertia_renderer.send(:view_data).merge(page: page)
+          locals: { page: page }
         )
       end
     end


### PR DESCRIPTION
TLDR: `view_data` doesn't work right now, removing it to resolve the deprecation error.

---

This is more of a question, but I thought a PR might be an easier format to discuss this.

This is hoping to resolve the deprecation warning [introduced](https://github.com/inertiajs/inertia-rails/commit/38751a2b7e133061821bfaf5cef98b8ba449e931) since inertia_rails 3.12.1:

```
DEPRECATION WARNING: [DEPRECATION] 
Accessing `InertiaRails::Renderer#view_data` is deprecated and will be removed in v4.0
(called from InertiaBuilder::Renderer#render at inertia-builder/lib/inertia_builder/renderer.rb:26)
```

used in

https://github.com/rodrigotavio91/inertia-builder/blob/e49bedd04deb89e7bd71bf195872d181a110030d/lib/inertia_builder/renderer.rb#L23-L27

After looking through how everything is wired up, **I believe this is a no-op**, because:

1. `view_data:` is never passed when constructing the `InertiaRails::Renderer`, **so `@view_data` always defaults to `{}`**, making the merge no-op.

https://github.com/rodrigotavio91/inertia-builder/blob/e49bedd04deb89e7bd71bf195872d181a110030d/lib/inertia_builder/renderer.rb#L7-L14
  
2. There's no way to provide `view_data` right now. `Renderer` constructor only accepts `view_context`, `props` & `component`. The template doesn't try to extract anything out of it, either.

https://github.com/rodrigotavio91/inertia-builder/blob/e49bedd04deb89e7bd71bf195872d181a110030d/lib/inertia_builder/renderer.rb#L3-L5

3. InertiaBuilder does a sub-render `layout: false`. So even if `view_data` _were_ passed, it wouldn't reach the outer layout (via `content_for`) where `view_data` is typically used. 

https://github.com/rodrigotavio91/inertia-builder/blob/e49bedd04deb89e7bd71bf195872d181a110030d/lib/inertia_builder/renderer.rb#L23-L27

Thus, this PR removes it to "fix" the deprecation warning.

(I don't personally use [the `view_data` feature](https://inertia-rails.dev/guide/responses#passing-additional-data-to-the-view) yet. And I can't think of a clean API to provide it, other than _maybe_ a `view_data!` in the template file. 😅)

---

Thanks and open to suggestions! 

